### PR TITLE
Fix multiple issues in orchestrator scripts to ensure they work correctly

### DIFF
--- a/scripts/automation/git_hooks/pre-commit
+++ b/scripts/automation/git_hooks/pre-commit
@@ -54,7 +54,34 @@ else
   echo ""
 fi
 
-# 1. Format staged files
+# 1. Check orchestrator script permissions
+echo "🔒 Checking orchestrator script permissions..."
+PERMISSION_ERRORS=0
+
+# Check read/ scripts (must NOT be executable)
+while IFS= read -r -d '' script; do
+  if [[ -x "$script" ]]; then
+    echo "   ❌ $script should NOT be executable (use chmod 644)"
+    PERMISSION_ERRORS=$((PERMISSION_ERRORS + 1))
+  fi
+done < <(find scripts/versioning/file_versioning/orchestrators/read -name '*.sh' -type f -print0 2>/dev/null)
+
+# Check execute/ scripts (must BE executable)
+while IFS= read -r -d '' script; do
+  if [[ ! -x "$script" ]]; then
+    echo "   ❌ $script should be executable (use chmod 755)"
+    PERMISSION_ERRORS=$((PERMISSION_ERRORS + 1))
+  fi
+done < <(find scripts/versioning/file_versioning/orchestrators/execute -name '*.sh' -type f -print0 2>/dev/null)
+
+if [[ $PERMISSION_ERRORS -gt 0 ]]; then
+  echo ""
+  echo "❌ Script permission errors detected!"
+  echo "   Convention: read/ scripts = 644, execute/ scripts = 755"
+  exit 1
+fi
+
+# 2. Format staged files
 echo "✨ Formatting code..."
 if ! cargo fmt --all; then
   echo ""

--- a/scripts/versioning/file_versioning/orchestrators/execute/ci_watch_pr.sh
+++ b/scripts/versioning/file_versioning/orchestrators/execute/ci_watch_pr.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # If no PR number provided, tries to find PR for current branch
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # shellcheck source=scripts/common_lib/core/logging.sh
 source "$ROOT_DIR/scripts/common_lib/core/logging.sh"

--- a/scripts/versioning/file_versioning/orchestrators/execute/labels_sync.sh
+++ b/scripts/versioning/file_versioning/orchestrators/execute/labels_sync.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: ./labels_sync.sh [labels-file]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # shellcheck source=scripts/common_lib/core/logging.sh
 source "$ROOT_DIR/scripts/common_lib/core/logging.sh"

--- a/scripts/versioning/file_versioning/orchestrators/execute/start_work.sh
+++ b/scripts/versioning/file_versioning/orchestrators/execute/start_work.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   3. Create branch (from issue or custom)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # Save current branch to restore on exit (handle detached HEAD safely)
 INITIAL_BRANCH="$(git branch --show-current 2>/dev/null || true)"
@@ -77,7 +77,7 @@ echo ""
 read -rp "Your choice: " choice
 
 case "$choice" in
-  [0-9]+)
+  [0-9]*)
     # Validate issue number format strictly
     if ! [[ "$choice" =~ ^[0-9]+$ ]]; then
       die "Invalid issue number: $choice"
@@ -114,7 +114,7 @@ case "$choice" in
       read -rp "Enter custom branch name: " BRANCH_NAME
     fi
 
-    bash "$SCRIPT_DIR/git/create_branch.sh" "$BRANCH_NAME"
+    bash "$ROOT_DIR/scripts/versioning/file_versioning/git/create_branch.sh" "$BRANCH_NAME"
     ;;
 
   [Cc])
@@ -126,7 +126,7 @@ case "$choice" in
     read -rp "Enter branch name: " BRANCH_NAME
 
     validate_branch_name "$BRANCH_NAME"
-    bash "$SCRIPT_DIR/../read/git/create_branch.sh" "$BRANCH_NAME"
+    bash "$ROOT_DIR/scripts/versioning/file_versioning/git/create_branch.sh" "$BRANCH_NAME"
     ;;
 
   [Ss])

--- a/scripts/versioning/file_versioning/orchestrators/read/check_priority_issues.sh
+++ b/scripts/versioning/file_versioning/orchestrators/read/check_priority_issues.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Lists high priority and security issues from GitHub
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # shellcheck source=scripts/common_lib/core/logging.sh
 source "$ROOT_DIR/scripts/common_lib/core/logging.sh"

--- a/scripts/versioning/file_versioning/orchestrators/read/create_pr.sh
+++ b/scripts/versioning/file_versioning/orchestrators/read/create_pr.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: ./create_pr.sh [--base <branch>] [--title <title>] [--body <body>] [--draft]
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # shellcheck source=scripts/common_lib/core/logging.sh
 source "$ROOT_DIR/scripts/common_lib/core/logging.sh"
@@ -59,7 +59,12 @@ info "Creating PR for branch: $CURRENT_BRANCH → $BASE_BRANCH"
 if [[ -z "$TITLE" ]]; then
   # Extract type and description from branch name (e.g., feat/add-login → Add login)
   if [[ "$CURRENT_BRANCH" =~ ^(feat|fix|chore|refactor|docs|test)/(.+)$ ]]; then
-    TITLE="$(echo "$CURRENT_BRANCH" | sed -E 's|^(feat|fix|chore|refactor|docs|test)/|\U\1: |' | sed -E 's|-| |g')"
+    TYPE="${BASH_REMATCH[1]}"
+    DESC="${BASH_REMATCH[2]}"
+    # Capitalize first letter and replace hyphens with spaces
+    TYPE_CAPITALIZED="$(echo "${TYPE:0:1}" | tr '[:lower:]' '[:upper:]')${TYPE:1}"
+    DESC_FORMATTED="$(echo "$DESC" | sed -E 's|-| |g')"
+    TITLE="${TYPE_CAPITALIZED}: ${DESC_FORMATTED}"
   else
     TITLE="$CURRENT_BRANCH"
   fi

--- a/scripts/versioning/file_versioning/orchestrators/read/synch_main_dev.sh
+++ b/scripts/versioning/file_versioning/orchestrators/read/synch_main_dev.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 
 # shellcheck source=scripts/common_lib/core/logging.sh
 source "$ROOT_DIR/scripts/common_lib/core/logging.sh"
@@ -12,6 +12,9 @@ source "$ROOT_DIR/scripts/common_lib/core/command.sh"
 source "$ROOT_DIR/scripts/common_lib/versioning/file_versioning/git/repo.sh"
 # shellcheck source=scripts/common_lib/versioning/file_versioning/git/working_tree.sh
 source "$ROOT_DIR/scripts/common_lib/versioning/file_versioning/git/working_tree.sh"
+
+# Validate dependencies
+require_cmd gh
 
 REMOTE="${REMOTE:-origin}"
 MAIN="${MAIN:-main}"


### PR DESCRIPTION
### Summary

Fix orchestrator scripts to ensure proper path resolution, dependency checking, and permission enforcement.

The orchestrator scripts had incorrect relative paths that prevented them from finding shared utilities and the project root. Additionally, some scripts used BSD-specific syntax incompatible with Linux, and there was no validation of the read/ vs execute/ permission convention.

**What was fixed:**
- All orchestrator scripts now correctly calculate ROOT_DIR by going up the right number of directory levels
- Replaced BSD sed syntax with POSIX-compatible bash string manipulation
- Added pre-commit validation to enforce permission convention (read/ = 644, execute/ = 755)
- Fixed paths to git utilities to use absolute paths instead of non-existent relative directories
- Added explicit dependency check for GitHub CLI in scripts that require it

## Test Plan

- [x] Scripts tested and working
- [x] Permission check validates 644 vs 755 correctly
- [x] All tests pass
- [x] No changes to runtime code