### PR TITLE
PR Dev into Main

### DIFF
--- a/.github/workflows/ci_automation_sync.yml
+++ b/.github/workflows/ci_automation_sync.yml
@@ -1,0 +1,71 @@
+name: Automation - Sync main to dev
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-main-to-dev:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 🔐 Token GitHub App
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Export token
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
+      - name: Configure Git
+        run: |
+          git config user.name "automation-project-bot"
+          git config user.email "automation-bot@users.noreply.github.com"
+
+      - name: Fetch branches
+        run: git fetch origin
+
+      - name: Check if sync needed
+        id: check
+        run: |
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "sync_needed=false" >> $GITHUB_OUTPUT
+          else
+            echo "sync_needed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create sync branch
+        if: steps.check.outputs.sync_needed == 'true'
+        run: |
+          git switch -C chore/sync-main-into-dev origin/dev
+          git merge --no-edit origin/main
+          git push -u origin chore/sync-main-into-dev --force-with-lease
+
+      - name: Create PR
+        if: steps.check.outputs.sync_needed == 'true'
+        run: |
+          if ! gh pr list --base dev --head chore/sync-main-into-dev --state open --json number --jq 'length > 0' | grep -q true; then
+            gh pr create \
+              --base dev \
+              --head chore/sync-main-into-dev \
+              --title "chore: sync main into dev" \
+              --body "Automated sync after merge into main."
+          fi
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.sync_needed == 'true'
+        run: gh pr merge chore/sync-main-into-dev --auto --merge

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -1,0 +1,37 @@
+name: Rust CI (dev)
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Cargo test
+        run: cargo test --workspace --all-features --verbose

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -1,0 +1,54 @@
+name: Rust CI (main)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  gate:
+    name: Gate PR sources into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Allow only dev or hotfix/* into main
+        run: |
+          HEAD="${{ github.head_ref }}"
+          if [[ "$HEAD" == "dev" || "$HEAD" == hotfix/* ]]; then
+            echo "OK: $HEAD can merge into main"
+            exit 0
+          fi
+          echo "ERROR: PRs into main must come from 'dev' or 'hotfix/*'. Got: $HEAD"
+          exit 1
+
+  ci:
+    name: Rust CI
+    runs-on: ubuntu-latest
+    needs: [gate]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: Cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Cargo test
+        run: cargo test --workspace --all-features --verbose

--- a/scripts/automation/git_hooks/commit-msg
+++ b/scripts/automation/git_hooks/commit-msg
@@ -15,7 +15,8 @@ fi
 ALLOWED_TYPES="^(feature|feat|fix|fixture|doc|docs|refactor|test|tests|chore)"
 
 # Validate format: <type>(<scope>): <message> or <type>: <message>
-if [[ ! "$COMMIT_MSG" =~ $ALLOWED_TYPES(\([a-zA-Z0-9_/-]+\))?:\ .+ ]]; then
+# Allows multiple scopes separated by commas: feat(ci,scripts/versioning): message
+if [[ ! "$COMMIT_MSG" =~ $ALLOWED_TYPES(\([a-zA-Z0-9_/,-]+\))?:\ .+ ]]; then
   echo "❌ Invalid commit message format!"
   echo ""
   echo "Expected format:"
@@ -28,6 +29,7 @@ if [[ ! "$COMMIT_MSG" =~ $ALLOWED_TYPES(\([a-zA-Z0-9_/-]+\))?:\ .+ ]]; then
   echo ""
   echo "Examples:"
   echo "  feat(auth): add user authentication"
+  echo "  feat(ci,scripts): add workflows and sync script"
   echo "  fix: resolve null pointer exception"
   echo "  docs(readme): update installation instructions"
   echo ""


### PR DESCRIPTION
- Enhance synch_main_dev.sh :
  • More robust detection with commit counting (git rev-list)
  • Create sync branch from dev instead of main (preserves dev commits)
  • Merge main into sync branch (safer in team environment)
  • Update local dev before creating sync branch
  • Use git branch instead of git switch for local main creation

- Add .github/workflows/ci_main.yml :
  • Gate PR: only allow dev or hotfix/* into main
  • Full CI: fmt, clippy, tests on entire workspace

- Add .github/workflows/ci_dev.yml :
  • Complete CI on push/PR to dev branch
  • Same checks as main (consistency)

- Add .github/workflows/ci_automation_sync.yml :
  • Triggered after merge into main
  • Uses GitHub App token (BOT_APP_ID/PRIVATE_KEY)
  • Automatically creates main→dev sync PR with auto-merge
  • Checks if sync needed before creating branch