### PR TITLE
fix(ci): use --force flag for idempotent label creation

### DIFF
--- a/.github/workflows/ci_automation_sync.yml
+++ b/.github/workflows/ci_automation_sync.yml
@@ -100,12 +100,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          if ! gh label view "automation-failed" --repo "$GH_REPO" >/dev/null 2>&1; then
-            gh label create "automation-failed" \
-              --repo "$GH_REPO" \
-              --color "FF0000" \
-              --description "Automation sync failed"
-          fi
+          gh label create "automation-failed" \
+            --repo "$GH_REPO" \
+            --color "FF0000" \
+            --description "Automation sync failed" \
+            --force || true
 
       - name: Add failure label to source PR
         if: failure()


### PR DESCRIPTION
**Fix for:** Automation sync workflow failure due to label creation error

**Problem:**
The automation sync workflow fails when trying to create the 'automation-failed' label if it already exists. The previous check-then-create pattern had a logic flaw.

**Solution:**
- Use `gh label create` with `--force` flag to idempotently create/update the label
- Add `|| true` to ensure the step doesn't fail even if label creation fails (graceful degradation)
- Simplifies the logic and makes it more robust

**Affected Steps:**
- Ensure failure label exists

**Commit:** aa26414