### PR TITLE
fix(scripts/automation/git_hooks): fallback to origin/dev when no upstream exists

### DIFF
--- a/scripts/automation/git_hooks/pre-push
+++ b/scripts/automation/git_hooks/pre-push
@@ -16,12 +16,17 @@ echo ""
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT" || exit 1
 
+# Get commit messages from commits being pushed
+UPSTREAM_BRANCH="$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "")"
+if [[ -z "$UPSTREAM_BRANCH" ]]; then
+  echo "⚠️  No upstream branch detected. Falling back to origin/dev for scope detection."
+  UPSTREAM_BRANCH="origin/dev"
+fi
+
+commits=$(git log "$UPSTREAM_BRANCH"..HEAD --format=%B 2>/dev/null)
+
 # Extract crate names from commit scopes
 detect_crates_from_scopes() {
-  # Get commit messages from commits being pushed
-  local commits
-  commits=$(git log @{u}..HEAD --format=%B 2>/dev/null)
-
   local crates=()
   local invalid_scopes=0
   local scope_re='^[a-z]+\(([^)]+)\):'


### PR DESCRIPTION
## Summary
- Fall back to origin/dev for scope detection when no upstream exists

## Testing
- pre-push hook

## Issue
Closes #159