### PR TITLE
docs: add scripts TOC and update references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Contributions are welcome. Keep changes focused, follow existing structure, and link your work to an issue when possible.
 
-For detailed workflow documentation, see the [Git Workflow Guide](documentation/technical_documentation/versioning/file_versioning/git/TOC.md).
+For detailed workflow documentation, see the [scripts TOC](scripts/TOC.md).
 
 ---
 
@@ -48,7 +48,7 @@ Use descriptive branch names with a type prefix:
 - Use clear, descriptive commit messages.
 - Reference issues when applicable: `fix: Resolve panic in parser (#42)`
 
-See [Commit Guidelines](documentation/technical_documentation/versioning/file_versioning/git/commit.md) for details.
+See [Git scripts TOC](scripts/versioning/file_versioning/git/TOC.md) for details.
 
 ---
 
@@ -83,7 +83,7 @@ See [Commit Guidelines](documentation/technical_documentation/versioning/file_ve
 - **Size**: Keep PRs focused; split large changes into smaller PRs
 - **Tests**: Include tests for new functionality
 
-See [Pull Request Guide](documentation/technical_documentation/versioning/file_versioning/git/pull_request.md) for details.
+See [Versioning TOC](scripts/versioning/file_versioning/TOC.md) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ For details, see the architecture doc: `documentation/technical_documentation/AR
 
 Internal documentation is available in the `documentation/` folder. Start with the [Documentation Index](documentation/TOC.md), or jump directly to the [Technical Documentation TOC](documentation/technical_documentation/TOC.md).
 
+Scripts documentation is indexed in [scripts/TOC.md](scripts/TOC.md).
+
 ## Contribute
 
 Contributions are welcome! Please open an issue or a pull request on the GitHub repository.
 
-For more details on the Git/GitHub workflow used in this project, see the [versioning documentation](documentation/technical_documentation/versioning/file_versioning/git/TOC.md).
+For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Licenses
 

--- a/documentation/technical_documentation/TOC.md
+++ b/documentation/technical_documentation/TOC.md
@@ -7,8 +7,7 @@ This document lists the various sections of the internal documentation for the `
 ## Documentation
 
 - [Automated Documentation](documentation.md): Details on how documentation is generated and maintained.
-- [Automation Scripts](../../scripts/automation/README.md): Practical automation docs (scripts).
-- [Versioning Scripts](../../scripts/versioning/file_versioning/README.md): Versioning workflow docs (scripts).
+- [Scripts TOC](../../scripts/TOC.md): Entry point for automation + versioning + common_lib.
 - [System Processes](system_processes.md): How core processes are launched and supervised.
 - [Libraries and Symbolic Components](projects/projects_libraries.md): Information about shared libraries and symbolic components.
 - [Products and Workspace Components](projects/projects_products.md): Details on the products and components within the workspace.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ Scripts are organized by **what they do** (responsibility), not by the tools the
 For complete details about all scripts:
 
 - See the README in each domain directory
-- Full documentation: `documentation/technical_documentation/versioning/file_versioning/scripts_overview.md`
+- See the scripts TOC: `scripts/TOC.md`
 
 ## Quick Reference
 

--- a/scripts/TOC.md
+++ b/scripts/TOC.md
@@ -1,0 +1,9 @@
+# Scripts TOC
+
+- [Back to Repository](../README.md)
+
+## Domains
+
+- [Automation](automation/TOC.md)
+- [Versioning](versioning/TOC.md)
+- [Common Libraries](common_lib/TOC.md)

--- a/scripts/automation/TOC.md
+++ b/scripts/automation/TOC.md
@@ -1,0 +1,25 @@
+# Automation TOC
+
+- [Back to Scripts TOC](../TOC.md)
+
+## Overview
+
+- [Automation README](README.md)
+- [Git Hooks](git_hooks/TOC.md)
+
+## Scripts
+
+- [audit_security.sh](audit_security.sh)
+- [build_accounts_ui.sh](build_accounts_ui.sh)
+- [build_and_check_ui_bundles.sh](build_and_check_ui_bundles.sh)
+- [build_ui_bundles.sh](build_ui_bundles.sh)
+- [changed_crates.sh](changed_crates.sh)
+- [check_dependencies.sh](check_dependencies.sh)
+- [check_merge_conflicts.sh](check_merge_conflicts.sh)
+- [clean_artifacts.sh](clean_artifacts.sh)
+- [pre_add_review.sh](pre_add_review.sh)
+- [pre_push_check.sh](pre_push_check.sh)
+- [release_prepare.sh](release_prepare.sh)
+- [setup_hooks.sh](setup_hooks.sh)
+- [sync_docs.sh](sync_docs.sh)
+- [test_coverage.sh](test_coverage.sh)

--- a/scripts/automation/git_hooks/TOC.md
+++ b/scripts/automation/git_hooks/TOC.md
@@ -1,0 +1,14 @@
+# Git Hooks TOC
+
+- [Back to Automation TOC](../TOC.md)
+
+## Overview
+
+- [Git Hooks README](README.md)
+
+## Hooks
+
+- [commit-msg](commit-msg)
+- [pre-commit](pre-commit)
+- [pre-push](pre-push)
+- [install_hooks.sh](install_hooks.sh)

--- a/scripts/common_lib/TOC.md
+++ b/scripts/common_lib/TOC.md
@@ -1,0 +1,21 @@
+# Common Libraries TOC
+
+- [Back to Scripts TOC](../TOC.md)
+
+## Overview
+
+- [Common Lib README](README.md)
+- [Core Libraries](core/README.md)
+- [Versioning Libraries](versioning/README.md)
+
+## Core Libraries
+
+- [command.sh](core/command.sh)
+- [file_operations.sh](core/file_operations.sh)
+- [logging.sh](core/logging.sh)
+- [network_utils.sh](core/network_utils.sh)
+- [string_utils.sh](core/string_utils.sh)
+
+## Versioning Libraries
+
+- [file_versioning](versioning/file_versioning/TOC.md)

--- a/scripts/common_lib/versioning/file_versioning/TOC.md
+++ b/scripts/common_lib/versioning/file_versioning/TOC.md
@@ -1,0 +1,16 @@
+# Common Lib (Versioning) TOC
+
+- [Back to Common Libraries TOC](../../TOC.md)
+
+## Overview
+
+- [file_versioning README](README.md)
+
+## Git Helpers
+
+- [branch.sh](git/branch.sh)
+- [commit.sh](git/commit.sh)
+- [repo.sh](git/repo.sh)
+- [staging.sh](git/staging.sh)
+- [synch.sh](git/synch.sh)
+- [working_tree.sh](git/working_tree.sh)

--- a/scripts/versioning/TOC.md
+++ b/scripts/versioning/TOC.md
@@ -1,0 +1,8 @@
+# Versioning TOC
+
+- [Back to Scripts TOC](../TOC.md)
+
+## Overview
+
+- [Versioning README](README.md)
+- [File Versioning](file_versioning/TOC.md)

--- a/scripts/versioning/file_versioning/README.md
+++ b/scripts/versioning/file_versioning/README.md
@@ -122,5 +122,4 @@ Example: `feature/user-authentication`, `fix/null-pointer-bug`
 
 For detailed workflow documentation, see:
 
-- [Git Workflow Pipeline](../../../documentation/technical_documentation/workflows/versioning/file_versioning/git/pipeline_overview.md)
-- [Scripts Overview](../../../documentation/technical_documentation/workflows/versioning/file_versioning/scripts_overview.md)
+- [Scripts TOC](../../TOC.md)

--- a/scripts/versioning/file_versioning/TOC.md
+++ b/scripts/versioning/file_versioning/TOC.md
@@ -1,0 +1,13 @@
+# File Versioning TOC
+
+- [Back to Versioning TOC](../TOC.md)
+
+## Overview
+
+- [File Versioning README](README.md)
+
+## Sections
+
+- [Orchestrators](orchestrators/TOC.md)
+- [Git Scripts](git/TOC.md)
+- [GitHub Scripts](github/TOC.md)

--- a/scripts/versioning/file_versioning/git/TOC.md
+++ b/scripts/versioning/file_versioning/git/TOC.md
@@ -1,0 +1,20 @@
+# Git Scripts TOC
+
+- [Back to File Versioning TOC](../TOC.md)
+
+## Overview
+
+- [Git README](README.md)
+
+## Scripts
+
+- [add_commit_push.sh](add_commit_push.sh)
+- [clean_branches.sh](clean_branches.sh)
+- [clean_local_gone.sh](clean_local_gone.sh)
+- [cleanup_after_pr.sh](cleanup_after_pr.sh)
+- [create_after_delete.sh](create_after_delete.sh)
+- [create_branch.sh](create_branch.sh)
+- [create_work_branch.sh](create_work_branch.sh)
+- [delete_branch.sh](delete_branch.sh)
+- [finish_branch.sh](finish_branch.sh)
+- [push_branch.sh](push_branch.sh)

--- a/scripts/versioning/file_versioning/github/TOC.md
+++ b/scripts/versioning/file_versioning/github/TOC.md
@@ -1,0 +1,7 @@
+# GitHub Scripts TOC
+
+- [Back to File Versioning TOC](../TOC.md)
+
+## Overview
+
+- [GitHub README](README.md)

--- a/scripts/versioning/file_versioning/orchestrators/TOC.md
+++ b/scripts/versioning/file_versioning/orchestrators/TOC.md
@@ -1,0 +1,15 @@
+# Orchestrators TOC
+
+- [Back to File Versioning TOC](../TOC.md)
+
+## Overview
+
+- [Orchestrators README](README.md)
+
+## Execute (interactive)
+
+- [Execute TOC](execute/TOC.md)
+
+## Read (non-interactive)
+
+- [Read TOC](read/TOC.md)

--- a/scripts/versioning/file_versioning/orchestrators/execute/TOC.md
+++ b/scripts/versioning/file_versioning/orchestrators/execute/TOC.md
@@ -1,0 +1,13 @@
+# Orchestrators Execute TOC
+
+- [Back to Orchestrators TOC](../TOC.md)
+
+## Overview
+
+- [Execute README](README.md)
+
+## Scripts
+
+- [start_work.sh](start_work.sh)
+- [ci_watch_pr.sh](ci_watch_pr.sh)
+- [labels_sync.sh](labels_sync.sh)

--- a/scripts/versioning/file_versioning/orchestrators/read/TOC.md
+++ b/scripts/versioning/file_versioning/orchestrators/read/TOC.md
@@ -1,0 +1,13 @@
+# Orchestrators Read TOC
+
+- [Back to Orchestrators TOC](../TOC.md)
+
+## Overview
+
+- [Read README](README.md)
+
+## Scripts
+
+- [check_priority_issues.sh](check_priority_issues.sh)
+- [create_pr.sh](create_pr.sh)
+- [synch_main_dev_ci.sh](synch_main_dev_ci.sh)


### PR DESCRIPTION
Summary
- add multi-level TOCs under scripts/
- link scripts/README.md to scripts/TOC.md
- align CONTRIBUTING.md and repo README to scripts docs
- remove stale links in scripts versioning README

Testing
- not applicable (docs only)

Issue
Closes #171
Closes #103

@copilot