### PR TITLE
fix(ci): checkout base ref in sync workflow

### DIFF
--- a/.github/workflows/ci_automation_sync.yml
+++ b/.github/workflows/ci_automation_sync.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
Summary
- checkout the base ref in ci_automation_sync to avoid missing sync branch failures

Testing
- not applicable (workflow change)

Issue
Closes #177
