### PR TITLE
Update GitHub labels configuration

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -75,7 +75,7 @@
     "description": "Invalid issue or request (cannot be reproduced or not applicable)"
   },
   {
-    "name": "Linting",
+    "name": "linting",
     "color": "BFDADC",
     "description": "Lint rules, formatting enforcement, or static analysis issues"
   },
@@ -193,6 +193,11 @@
     "name": "projects/libraries/versioning",
     "color": "795548",
     "description": "Versioning, revisions, and history management"
+  },
+  {
+    "name": "projects/products/stable/accounts",
+    "color": "118AB2",
+    "description": "Stable accounts product"
   },
   {
     "name": "projects/products/stable/accounts/backend",


### PR DESCRIPTION
## What changed
- Updated `.github/labels.json`
- Normalized path-based labels (`projects/...`)
- Added missing crate labels
- Cleaned up obsolete labels
- Reworked colors for better readability
- Kept shared color only for:
  - `projects/products/stable/varina`
  - `projects/products/stable/varina/backend`
  - `projects/products/stable/varina/ui`
- Restored `workspace` label (yellow)

## Why
To make labels easier to read and keep GitHub labels aligned with the repository source of truth.