### PR TITLE
docs(workspace): enforce library layer boundaries

### DIFF
--- a/.github/workflows/ci_reusable.yml
+++ b/.github/workflows/ci_reusable.yml
@@ -78,6 +78,10 @@ jobs:
         if: steps.changes.outputs.run_rust_checks == 'true'
         uses: Swatinem/rust-cache@v2
 
+      - name: Check layer dependency boundaries
+        if: steps.changes.outputs.run_rust_checks == 'true'
+        run: ./scripts/checks/check_layer_boundaries.sh
+
       - name: Cargo fmt
         if: steps.changes.outputs.run_rust_checks == 'true'
         run: cargo fmt --all -- --check

--- a/documentation/technical_documentation/TOC.md
+++ b/documentation/technical_documentation/TOC.md
@@ -10,6 +10,7 @@ This document provides an overview of all documentation files in this directory.
 - [Documentation Template Standard](documentation_template_standard.md): Canonical template rules for README.md and TOC.md roles/sections
 - [Documentation Ownership Map](documentation_ownership_map.md): Ownership and maintenance expectations by documentation zone
 - [Flaky Test Stabilization Guide](flaky_tests.md): Workspace inventory and remediation workflow for flaky tests
+- [Library Layer Boundaries](library_layer_boundaries.md): CI-enforced dependency direction between libraries and products
 - [Labels Taxonomy](labels_taxonomy.md): Label naming and usage policy for issues and pull requests
 - [System Processes](system_processes.md): How core processes are launched and supervised
 - [Architecture](ARCHITECTURE.md): Description of the overall architecture of the project

--- a/documentation/technical_documentation/library_layer_boundaries.md
+++ b/documentation/technical_documentation/library_layer_boundaries.md
@@ -1,0 +1,33 @@
+# Library Layer Boundaries
+
+This document defines the automated dependency boundary enforced in CI.
+
+## Enforced Rule
+
+- Crates under `projects/libraries/` must not depend on crates under `projects/products/`.
+
+Allowed direction:
+
+- `projects/products/*` -> `projects/libraries/*`
+
+Forbidden direction:
+
+- `projects/libraries/*` -> `projects/products/*`
+
+## Validation
+
+CI runs:
+
+```bash
+./scripts/checks/check_layer_boundaries.sh
+```
+
+The check uses `cargo metadata` to inspect workspace dependency edges and fails when a forbidden edge is found.
+
+## Fix Guidance
+
+If CI reports a forbidden edge:
+
+1. Move shared logic into an appropriate crate under `projects/libraries/`.
+2. Make product crates consume the shared library crate.
+3. Remove direct product coupling from library crates.

--- a/scripts/checks/README.md
+++ b/scripts/checks/README.md
@@ -25,6 +25,28 @@ This directory contains validation and check scripts for the repository.
 
 **Related Documentation**: See `projects/products/README.md` for the complete stable/unstable product structure rules.
 
+### check_layer_boundaries.sh
+
+**Purpose**: Enforces workspace layer dependency boundaries to prevent architectural drift.
+
+**Usage**:
+
+```bash
+./scripts/checks/check_layer_boundaries.sh
+```
+
+**What it does**:
+
+- Runs `cargo metadata` to inspect workspace crate dependency edges
+- Classifies crates by path:
+  - `projects/libraries/*` => `library`
+  - `projects/products/*` => `product`
+- Fails when a `library -> product` dependency edge is detected
+
+**CI Integration**: Runs automatically in `.github/workflows/ci_reusable.yml`.
+
+**Related Documentation**: See `documentation/technical_documentation/library_layer_boundaries.md`.
+
 ## Adding New Checks
 
 When adding new validation scripts:

--- a/scripts/checks/check_layer_boundaries.sh
+++ b/scripts/checks/check_layer_boundaries.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Check workspace dependency boundaries between architecture layers.
+# Current enforced rule:
+# - Crates under projects/libraries/ must not depend on crates under projects/products/
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "❌ cargo is required to run layer boundary checks."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "❌ jq is required to run layer boundary checks."
+  exit 1
+fi
+
+echo "Checking workspace layer dependency boundaries..."
+
+metadata_json="$(cargo metadata --format-version 1 --all-features)"
+
+violations="$(
+  jq -r '
+    def layer_of($manifest_path):
+      if ($manifest_path | test("/projects/libraries/")) then "library"
+      elif ($manifest_path | test("/projects/products/")) then "product"
+      else "other"
+      end;
+
+    ( .workspace_members | map({(.): true}) | add ) as $workspace
+    | ( .packages
+        | map({
+            (.id): {
+              name: .name,
+              layer: layer_of(.manifest_path)
+            }
+          })
+        | add ) as $pkg_by_id
+    | [
+        .resolve.nodes[]?
+        | select($workspace[.id] == true)
+        | . as $node
+        | $pkg_by_id[$node.id] as $from
+        | $node.deps[]?
+        | select($workspace[.pkg] == true)
+        | $pkg_by_id[.pkg] as $to
+        | select($from.layer == "library" and $to.layer == "product")
+        | "\($from.name)\t\($to.name)"
+      ]
+    | unique
+    | .[]
+  ' <<< "$metadata_json"
+)"
+
+if [[ -z "$violations" ]]; then
+  echo "✅ Layer boundaries OK: no forbidden dependencies found."
+  exit 0
+fi
+
+echo "❌ Forbidden dependencies detected (library -> product):"
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  from_crate="${line%%$'\t'*}"
+  to_crate="${line#*$'\t'}"
+  echo "   - $from_crate -> $to_crate"
+done <<< "$violations"
+
+echo ""
+echo "How to fix:"
+echo "  1. Move shared code to projects/libraries/"
+echo "  2. Invert the dependency direction (product depends on library)"
+echo "  3. Remove product-level coupling from library crates"
+
+exit 1


### PR DESCRIPTION
### Description
Add architecture safeguards for workspace layering.

### Included Work
- Enforce layer dependency boundaries in CI
- Document boundary rules and remediation steps

### Issues
- Closes #520

### Validation
- Added `scripts/checks/check_layer_boundaries.sh`
- Wired check in `.github/workflows/ci_reusable.yml`
- Updated technical documentation TOC and boundary docs
